### PR TITLE
fix user rights for PGDATA folder

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 chown -R postgres "$PGDATA"
-chmod -R 700 "$PGDATA"
+chmod 700 "$PGDATA"
 
 if [ -z "$(ls -A "$PGDATA")" ]; then
     gosu postgres initdb --locale='de_DE.UTF-8'

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 chown -R postgres "$PGDATA"
+chmod -R 700 "$PGDATA"
 
 if [ -z "$(ls -A "$PGDATA")" ]; then
     gosu postgres initdb --locale='de_DE.UTF-8'


### PR DESCRIPTION
If postgres container is restarted, the following error comes up and prevents the container from starting:
```
FATAL:  data directory "/opt/postgresql/data" has group or world access
DETAIL:  Permissions should be u=rwx (0700).
```
This branch fixes this issue by setting the user rights for the PGDATA folder at the entrypoint.