### PR TITLE
old postgresql version is no longer available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM biggis/base:java8-jre-alpine
 
 MAINTAINER wipatrick
 
-ARG PG_MAJOR=9.6.0
-ARG PG_VERSION=9.6.0-r1
+ARG PG_MAJOR=9.6.2
+ARG PG_VERSION=9.6.2-r1
 
 ARG BUILD_DATE
 ARG VCS_REF


### PR DESCRIPTION
Change postgresql version because old version 9.6.0.r1 is no longer available anymore.