### PR TITLE
add health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,5 +36,10 @@ VOLUME ["/var/lib/postgresql/data/pgdata"]
 
 EXPOSE 5432
 
+ADD healthcheck.sh /opt/postgresql/
+
+HEALTHCHECK --interval=5s --timeout=3s --retries=20 \
+  CMD /opt/postgresql/healthcheck.sh
+
 ENTRYPOINT ["/var/lib/postgresql/start.sh"]
 CMD ["postgres"]

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -eo pipefail
+
+host="$(hostname --ip-address || echo '127.0.0.1')"
+user="${POSTGRES_USER:-postgres}"
+export PGPASSWORD="${POSTGRES_PASSWORD:-}"
+
+args=(
+	# force postgres to not use the local unix socket (test "external" connectibility)
+	--host "$host"
+	--username "$user"
+	--quiet --no-align --tuples-only
+)
+
+if select="$(echo 'SELECT 1' | psql "${args[@]}")" && [ "$select" = '1' ]; then
+	exit 0
+fi
+
+exit 1


### PR DESCRIPTION
Add a health check for the container for use with docker >= 1.12
This allows other containers which are depending on the postgres container to start only if database is started completely.